### PR TITLE
T15517 templates/boot: add extra_kernel_args for Depthcharge

### DIFF
--- a/templates/boot/generic-depthcharge-tftp-ramdisk-boot-template.jinja2
+++ b/templates/boot/generic-depthcharge-tftp-ramdisk-boot-template.jinja2
@@ -3,6 +3,9 @@
 {{ super() }}
 {% endblock %}
 {% block main %}
+{%- if extra_kernel_args %}
+{% do context.update({"extra_kernel_args": extra_kernel_args}) %}
+{% endif %}
 {{ super() }}
 {% endblock %}
 {% block actions %}


### PR DESCRIPTION
Similarly to the U-Boot template, if extra_kernel_args is defined then
add it to the job context for Depthcharge.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>