### PR TITLE
FIXUP fix kselftest tarball name with .tar.xz

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -666,7 +666,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
             'kdir': os.path.join(kdir, 'tools/testing/selftests')
         })
         opts.update({
-            'FORMAT': '.gz',
+            'FORMAT': '.xz',
         })
         # 'gen_tar' target does 'make install' and creates tarball
         result = _run_make(target='gen_tar', **kwargs)


### PR DESCRIPTION
A fix to squash-merge.